### PR TITLE
Remove reference to /mnt/disks/...

### DIFF
--- a/docker-template/flexconnect.xml
+++ b/docker-template/flexconnect.xml
@@ -43,6 +43,6 @@
   </Data>
   <Environment/>
   <Labels/>
-  <Config Name="Host Path 2" Target="/plex" Default="" Mode="ro" Description="Container Path: /plex" Type="Path" Display="always" Required="true" Mask="false">/mnt/disks/GANDALF_PMSData/Plex Media Server/</Config>
+  <Config Name="Host Path 2" Target="/plex" Default="" Mode="ro" Description="Container Path: /plex" Type="Path" Display="always" Required="true" Mask="false"></Config>
   <Config Name="AppData Config Path" Target="/config" Default="/mnt/user/appdata/FlexConnect" Mode="rw" Description="Container Path: /config" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/FlexConnect</Config>
 </Container>


### PR DESCRIPTION
Specific to your system, and will cause users nothing but trouble as that path will wind up getting created in RAM